### PR TITLE
Clawing back some more talk slots

### DIFF
--- a/docs/program.mdx
+++ b/docs/program.mdx
@@ -107,15 +107,15 @@ export const day2ProgramAfternoon = [
 ];
 
 export const day2ProgramEvening = [
-  { time: "19:00 - 19:30", title: "Presentations and Q&A", speaker: "TBA", room: "Zoom" },
+  { time: "19:00 - 19:45", title: "Presentations and Q&A", speaker: "TBA", room: "Zoom" },
   {
-    time: "19:30 - 21:00",
+    time: "19:45 - 21:15",
     title: "Breakout 4",
     speaker: "everyone",
     room: "Zoom breakout rooms",
   },
   {
-    time: "21:00 - 21:30",
+    time: "21:15 - 21:30",
     title: "Summing up Breakouts 3 & 4",
     speaker: "Moderators",
     room: "Zoom",


### PR DESCRIPTION
Here's a minimal proposal for filling talk slots, which gives us:

8 morning talks

6 afternoon talks

4 evening talks

for a total of 18.

Ideally we would load the afternoon up with more talks, so that we can have more EU/NA intermingling.
