### PR TITLE
Fix sponsor box layout

### DIFF
--- a/docs/components.jsx
+++ b/docs/components.jsx
@@ -2,10 +2,7 @@ import React from "react";
 import classNames from "classnames";
 
 export function Sponsor({ name, link, img, className }) {
-  const classes = classNames(
-    "col-12 col-md-6 d-flex justify-content-center",
-    className
-  );
+  const classes = classNames("col-12 col-md-6 d-flex sponsor-box", className);
 
   return (
     <div className={classes}>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -147,6 +147,7 @@ body {
 }
 
 .sponsor-box {
+  justify-content: center;
   align-items: center;
 }
 


### PR DESCRIPTION
Addressing #36.

#35 applied the `sponsor-box` to the parent container of all sponsors, instead of to each sponsor component, as intended. This PR remedies this error. 